### PR TITLE
Use data-s9e-livepreview-hash to skip DOM diffing

### DIFF
--- a/src/ConfigureTextFormatter.php
+++ b/src/ConfigureTextFormatter.php
@@ -80,7 +80,7 @@ class ConfigureTextFormatter
             if ($allowAsciiMath && ($delimiter['ascii'] === true)) {
                 $config->BBCodes->addCustom(
                     $delimiter['left'].'{TEXT}'.$delimiter['right'],
-                    '<span>
+                    '<span data-s9e-livepreview-hash="">
                         <xsl:attribute name="class">'.$classes[$className].'</xsl:attribute>
                         <xsl:attribute name="data-s9e-livepreview-onupdate">if(typeof katex!==\'undefined\')katex.render((typeof ascii2tex!==\'undefined\') ? ascii2tex.parse(this.innerText) : this.innerText, this, '.$options.')</xsl:attribute>
                         <xsl:apply-templates/>
@@ -101,7 +101,7 @@ class ConfigureTextFormatter
             } else {
                 $config->BBCodes->addCustom(
                     $delimiter['left'].'{TEXT}'.$delimiter['right'],
-                    '<span>
+                    '<span data-s9e-livepreview-hash="">
                         <xsl:attribute name="class">'.$classes[$className].'</xsl:attribute>
                         <xsl:attribute name="data-s9e-livepreview-onupdate">if(typeof katex!==\'undefined\')katex.render(this.innerText, this, '.$options.')</xsl:attribute>
                         <xsl:apply-templates/>


### PR DESCRIPTION
When `data-s9e-livepreview-hash` is set, the live preview algorithm will use it as a hint to determine whether to skip that entire branch of the DOM. Extensions like MathRen replace plain text with markup, so every time any part of the message is refreshed the fancy KaTeX markup reverts to text, then the live preview algorithm reruns the `data-s9e-livepreview-onupdate` code to change it back to KaTeX then does DOM diffing to see if the live DOM needs to be updated. If you set `data-s9e-livepreview-hash`, it will make a hash of the element's markup *before* the `update` event is run so it will only run it if the content actually changes. IOW, it won't run `katex.render()` on every keystroke. 

https://s9etextformatter.readthedocs.io/JavaScript/Live_preview_attributes/#data-s9e-livepreview-hash